### PR TITLE
Feature/cext 4353 default cache control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/plugin-source-headers",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/src/cachecontrol/getCacheControlDirectives.ts
+++ b/src/cachecontrol/getCacheControlDirectives.ts
@@ -9,28 +9,50 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { MappedHeader } from '../types/mesh';
+import { CustomSource, MappedHeader } from '../types/mesh';
 
 /**
  * Returns the lowest common denominator on all the sources cache-control headers
- * @param meshId
- * @param requestId unique UUID based on the HTTP request
- * @returns
+ * @param responseHeaders Mapped response headers
+ * @param queriedSources Source configurations used in the query
+ * @returns Cache control directives
  */
 export const getCacheControlDirectives = (
 	responseHeaders: MappedHeader[],
+	queriedSources: CustomSource[],
 ): { [k: string]: string } => {
 	let ccDirectives: {
 		[k: string]: string;
 	} = {};
 
+	// Collect whether each source has returned cache control headers
+	const sourceReturnedCacheControl: { [k: string]: boolean } = {};
+
+	// Get the cache-control directives from the response headers
 	responseHeaders?.forEach(element => {
 		if (element.name.toLowerCase() === 'cache-control') {
+			// Flag source as having returned cache control
+			if (!sourceReturnedCacheControl[element.source]) {
+				sourceReturnedCacheControl[element.source] = true;
+			}
 			const currentCacheMap = parseCacheControl(element.values.toString());
-			const standardDizedCacheMap = Object.fromEntries(
+			const standardizedCacheMap = Object.fromEntries(
 				Object.entries(currentCacheMap).map(([k, v]) => [k.toLowerCase(), v.toLowerCase()]),
 			);
-			ccDirectives = resolveCacheDirectives(ccDirectives, standardDizedCacheMap);
+			ccDirectives = resolveCacheDirectives(ccDirectives, standardizedCacheMap);
+		}
+	});
+
+	// Get the cache config for the sources based on sources involved in query
+	queriedSources.forEach(sourceConfig => {
+		const sourceConfigCacheControl = sourceConfig?.responseConfig?.cache?.cacheControl;
+		// If source used in query did not return cache control, consider the default for the source
+		if (!sourceReturnedCacheControl[sourceConfig.name] && sourceConfigCacheControl) {
+			const currentCacheMap = parseCacheControl(sourceConfigCacheControl);
+			const standardizedCacheMap = Object.fromEntries(
+				Object.entries(currentCacheMap).map(([k, v]) => [k.toLowerCase(), v.toLowerCase()]),
+			);
+			ccDirectives = resolveCacheDirectives(ccDirectives, standardizedCacheMap);
 		}
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { MappedHeader } from './types/mesh';
+import { MappedHeader, MeshConfig } from './types/mesh';
 import { MeshPlugin, OnFetchHookDonePayload, OnFetchHookPayload } from '@graphql-mesh/types';
 import { Plugin } from 'graphql-yoga';
 import {
@@ -29,9 +29,25 @@ type YogaMeshPlugin = Plugin<Context> & MeshPlugin<Context>;
  * @param meshConfig Mesh configuration
  */
 //TODO: Add type for meshConfig
-function useSourceHeaders(meshConfig: any): YogaMeshPlugin {
+function useSourceHeaders(meshConfig: MeshConfig): YogaMeshPlugin {
+	// Map containing sources queried per request
+	const mappedSources = new WeakMap<Request, Set<string>>();
+
 	// Map containing source headers per request.
 	const mappedHeaders = new WeakMap<Request, MappedHeader[]>();
+
+	/**
+	 * Get sources for a given request.
+	 * @param request Incoming request.
+	 */
+	function getMappedSources(request: Request) {
+		let sources = mappedSources.get(request);
+		if (!sources) {
+			sources = new Set();
+			mappedSources.set(request, sources);
+		}
+		return sources;
+	}
 
 	/**
 	 * Get source response headers for a given request.
@@ -56,9 +72,12 @@ function useSourceHeaders(meshConfig: any): YogaMeshPlugin {
 		onFetch: ({ context, info }: OnFetchHookPayload<Context>) => {
 			if (context != null) {
 				return ({ response }: OnFetchHookDonePayload) => {
-					const mappedHeaders = getMappedHeaders(context.request);
+					const mappedSources = getMappedSources(context.request);
 					const sourceName =
 						(info as GraphQLResolveInfo & { sourceName: string })?.sourceName || 'undefined';
+					mappedSources.add(sourceName);
+
+					const mappedHeaders = getMappedHeaders(context.request);
 
 					// Cookies
 					// @ts-ignore
@@ -83,22 +102,26 @@ function useSourceHeaders(meshConfig: any): YogaMeshPlugin {
 		 * @param response Outgoing response.
 		 */
 		onResponse({ request, response }: Context) {
-			const mappedRequestHeaders = getMappedHeaders(request);
+			const sourcesQueried = getMappedSources(request);
+			const mappedResponseHeaders = getMappedHeaders(request);
 
-			// Clean up mapped headers
+			// Clean up maps
+			mappedSources.delete(request);
 			mappedHeaders.delete(request);
 
-			// Process mesh response headers
+			// Get source response headers. This list should contain all response headers allowed to be included in response.
 			const sourceResponseHeaders = getSourceResponseHeaders(
 				meshConfig,
-				mappedRequestHeaders,
+				mappedResponseHeaders,
 				shouldIncludeMetadata(request),
 			);
+
+			// Get processed response headers. This list should contain final response headers for the response.
 			const processedResponseHeaders = processMeshResponseHeaders(
-				meshConfig.responseConfig,
+				meshConfig.responseConfig || {},
+				meshConfig.sources.filter(source => sourcesQueried.has(source.name)),
+				mappedResponseHeaders,
 				sourceResponseHeaders,
-				request.method,
-				mappedRequestHeaders,
 			);
 			updateHeaders(response, processedResponseHeaders);
 		},

--- a/src/responseHeaders/getSourceResponseHeaders.ts
+++ b/src/responseHeaders/getSourceResponseHeaders.ts
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { MappedHeader, SourceConfig } from '../types/mesh';
+import { CustomSource, MappedHeader, MeshConfig } from '../types/mesh';
 
 /**
  * Runs business logic on the response headers passed in based on the includeMetadata flag
@@ -19,8 +19,7 @@ import { MappedHeader, SourceConfig } from '../types/mesh';
  * @returns
  */
 export const getSourceResponseHeaders = (
-	//TODO: Add type for meshConfig
-	meshConfig: any,
+	meshConfig: MeshConfig,
 	responseHeaders: MappedHeader[] | undefined,
 	includeMetadata: boolean
 ): { [k: string]: string[] } => {
@@ -29,7 +28,7 @@ export const getSourceResponseHeaders = (
 	} = {};
 	const sourceResponseHeadersMap = new Map<string, string[]>();
 	if (meshConfig) {
-		meshConfig.sources.forEach((source: SourceConfig) => {
+		meshConfig.sources.forEach((source: CustomSource) => {
 			if (source.responseConfig && source.responseConfig.headers) {
 				sourceResponseHeadersMap.set(source.name, source.responseConfig.headers);
 			}

--- a/src/responseHeaders/processMeshResponseHeaders.ts
+++ b/src/responseHeaders/processMeshResponseHeaders.ts
@@ -10,31 +10,31 @@ governing permissions and limitations under the License.
 */
 
 import { getCacheControlDirectives } from '../cachecontrol/getCacheControlDirectives';
-import { MappedHeader, MeshResponseConfig } from '../types/mesh';
+import { CustomSource, MappedHeader, ResponseConfig } from '../types/mesh';
 
 /**
  * This function takes in the mesh config response headers as well as the source response headers
  * and performs business logic on what to return back. This function also runs the lowest common
  * denominator algorithm on the cache-control headers to return back to the user
- * @param meshResponseConfig response headers defined in the mesh config
- * @param sourceResponseConfig source response headers based on source response config
- * @param method Is this a GET,POST,PUT,DELETE
- * @param responseHeaders source response headers returned back from the query
+ * @param meshResponseConfig mesh response configuration
+ * @param queriedSources source configurations used in the query
+ * @param responseHeaders all response headers from the query
+ * @param sourceResponseHeaders source response headers returned back from the query
  * @returns
  */
 export const processMeshResponseHeaders = (
-	meshResponseConfig: MeshResponseConfig | undefined,
-	sourceResponseConfig: { [k: string]: string[] },
-	method: string,
+	meshResponseConfig: ResponseConfig,
+	queriedSources: CustomSource[],
 	responseHeaders: MappedHeader[] | undefined,
+	sourceResponseHeaders: { [k: string]: string[] },
 ): { [k: string]: string | string[] } => {
 	// Start with source response headers based on source response configuration
-	let processedHeaders: { [k: string]: string | string[] } = { ...(sourceResponseConfig || {}) };
+	let processedHeaders: { [k: string]: string | string[] } = { ...sourceResponseHeaders } || {};
 
 	// Always include the lowest common denominator cache-control header. This header is calculated based all response
 	// headers regardless of the source response configuration headers.
 	if (responseHeaders) {
-		const ccDirectives = getCacheControlDirectives(responseHeaders);
+		const ccDirectives = getCacheControlDirectives(responseHeaders, queriedSources);
 		processedHeaders = { ...processedHeaders, ...ccDirectives };
 	}
 

--- a/src/types/mesh.ts
+++ b/src/types/mesh.ts
@@ -22,10 +22,6 @@ export interface SourceResponseConfig {
 	headers?: string[];
 }
 
-export interface SourceConfig extends YamlConfig.Source {
-	responseConfig?: SourceResponseConfig;
-}
-
 export declare type CORSOptions = {
 	origin?: string[] | string;
 	methods?: string[];
@@ -36,9 +32,43 @@ export declare type CORSOptions = {
 	preflightContinue?: boolean;
 };
 
-export interface MeshResponseConfig {
+export interface CustomSource extends YamlConfig.Source {
+	responseConfig?: SourceResponseConfig;
+}
+
+export interface SourceResponseConfig {
+	headers?: string[];
+	/**
+	 * Source cache configuration.
+	 */
+	cache?: CacheConfig;
+}
+
+/**
+ * Cache configuration.
+ */
+export interface CacheConfig {
+	/**
+	 * Comma-delimited cache control directives. Similar to the HTTP cache control header.
+	 * @see https://www.rfc-editor.org/rfc/rfc9111.html#name-cache-control
+	 */
+	cacheControl?: string;
+}
+
+export interface MeshConfig {
+	sources: CustomSource[];
+	responseConfig?: ResponseConfig;
+}
+
+export interface ResponseConfig {
 	headers?: {
 		[k: string]: string;
 	};
 	CORS?: CORSOptions;
+	includeHTTPDetails?: boolean;
+	/**
+	 * Whether response caching is enabled.
+	 * @ignore Property is not considered for JSON schema generation.
+	 */
+	cache?: boolean;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Supports using new source cache control property that acts as a default for the source.

## Related Issue

CEXT-4353

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- Linked to `@adobe/aio-cli-plugin-api-mesh`
- `mesh.json` contains at least one source with new prop`source.responseConfig.cache.cacheControl`
- `aio api-mesh run mesh.json`

| Source Returns Header       | Source Default Configured                | Expected cache-control         |
|-----------------------------|------------------------------------------|--------------------------------|
|  </br>                           |                                          |                                |
| no-store                    |                                          | no-store                       |
|                             | public, max-age=5, s-maxage=10           | public, max-age=5, s-maxage=10 |
| no-store                    | public, max-age=5, s-maxage=10           | no-store                       |
| A: public, max-age=4</br>B: | A:</br>B: public, max-age=5, s-maxage=10 | public, max-age=4, s-maxage=10 |

## Screenshots (if appropriate):
Example source with default cache control `public, max-age=10` and does not return cache control in responses
![image](https://github.com/user-attachments/assets/4c07367d-e570-4d37-9fa7-8976f49ba7d8)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.